### PR TITLE
Use string interpolation to combine strings

### DIFF
--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule10.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule10.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1] << matches[2]
+            return "#{matches[0]}#{matches[1]}#{matches[2]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule11.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule11.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1]
+            return "#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule12.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule12.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 'pe' << matches[0]
+            return "pe#{matches[0]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule13a.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule13a.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 'm' << matches[0] << matches[1]
+            return "m#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule13b.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule13b.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 'p' << matches[0] << matches[1]
+            return "p#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule14.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule14.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1]
+            return "#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule15a.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule15a.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 'n' << matches[0] << matches[1]
+            return "n#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule15b.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule15b.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 't' << matches[0] << matches[1]
+            return "t#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule16.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule16.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1]
+            return "#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule17a.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule17a.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1]
+            return "#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule17b.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule17b.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 'k' << matches[0] << matches[1]
+            return "k#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule17d.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule17d.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 'ng' << matches[0] << matches[1]
+            return "ng#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule18a.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule18a.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 'ny' << matches[0] << matches[1]
+            return "ny#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule18b.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule18b.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 's' << matches[0] << matches[1]
+            return "s#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule19.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule19.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 'p' << matches[0] << matches[1]
+            return "p#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule1b.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule1b.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 'r' << matches[0]
+            return "r#{matches[0]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule2.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule2.rb
@@ -10,7 +10,7 @@ module Sastrawi
 
             return if /^er(.*)$/.match(matches[2])
 
-            return matches[0] << matches[1] << matches[2]
+            return "#{matches[0]}#{matches[1]}#{matches[2]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule20.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule20.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1] << matches[2]
+            return "#{matches[0]}#{matches[1]}#{matches[2]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule21a.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule21a.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1]
+            return "#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule21b.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule21b.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1]
+            return "#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule23.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule23.rb
@@ -10,7 +10,7 @@ module Sastrawi
 
             return if /^er(.*)$/.match(matches[2])
 
-            return matches[0] << matches[1] << matches[2]
+            return "#{matches[0]}#{matches[1]}#{matches[2]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule24.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule24.rb
@@ -10,7 +10,7 @@ module Sastrawi
 
             return if matches[0] == 'r'
 
-            return matches[0] << matches[1] << 'er' << matches[2] << matches[3]
+            return "#{matches[0]}#{matches[1]}er#{matches[2]}#{matches[3]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule25.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule25.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1]
+            return "#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule26a.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule26a.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 'm' << matches[0] << matches[1]
+            return "m#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule26b.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule26b.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 'p' << matches[0] << matches[1]
+            return "p#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule27.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule27.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1]
+            return "#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule28a.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule28a.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 'n' << matches[0] << matches[1]
+            return "n#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule28b.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule28b.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 't' << matches[0] << matches[1]
+            return "t#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule29.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule29.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1]
+            return "#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule3.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule3.rb
@@ -10,7 +10,7 @@ module Sastrawi
 
             return if matches[0] == 'r'
 
-            return matches[0] << matches[1] << 'er' << matches[2] << matches[3]
+            return "#{matches[0]}#{matches[1]}er#{matches[2]}#{matches[3]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule30a.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule30a.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1]
+            return "#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule30b.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule30b.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 'k' << matches[0] << matches[1]
+            return "k#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule31a.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule31a.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 'ny' << matches[0] << matches[1]
+            return "ny#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule31b.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule31b.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 's' << matches[0] << matches[1]
+            return "s#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule32.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule32.rb
@@ -10,7 +10,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1]
+            return "#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule34.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule34.rb
@@ -10,7 +10,7 @@ module Sastrawi
 
             return if /^er(.*)$/.match(matches[1])
 
-            return matches[0] << matches[1]
+            return "#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule35.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule35.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1] << matches[2]
+            return "#{matches[0]}#{matches[1]}#{matches[2]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule36.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule36.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1] << matches[2]
+            return "#{matches[0]}#{matches[1]}#{matches[2]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule37a.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule37a.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1] << matches[2]
+            return "#{matches[0]}#{matches[1]}#{matches[2]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule37b.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule37b.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1] << matches[2]
+            return "#{matches[0]}#{matches[1]}#{matches[2]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule38a.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule38a.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1] << matches[2]
+            return "#{matches[0]}#{matches[1]}#{matches[2]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule38b.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule38b.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1] << matches[2]
+            return "#{matches[0]}#{matches[1]}#{matches[2]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule39a.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule39a.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1] << matches[2]
+            return "#{matches[0]}#{matches[1]}#{matches[2]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule39b.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule39b.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1] << matches[2]
+            return "#{matches[0]}#{matches[1]}#{matches[2]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule40a.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule40a.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1] << matches[2]
+            return "#{matches[0]}#{matches[1]}#{matches[2]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule40b.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule40b.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1] << matches[2]
+            return "#{matches[0]}#{matches[1]}#{matches[2]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule5.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule5.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return matches[0] << matches[1] << matches[2]
+            return "#{matches[0]}#{matches[1]}#{matches[2]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule6b.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule6b.rb
@@ -8,7 +8,7 @@ module Sastrawi
           if contains
             matches = contains.captures
 
-            return 'r' << matches[0]
+            return "r#{matches[0]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule7.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule7.rb
@@ -10,7 +10,7 @@ module Sastrawi
 
             return if matches[0] == 'r'
 
-            return matches[0] << 'er' << matches[1]
+            return "#{matches[0]}er#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule8.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule8.rb
@@ -10,7 +10,7 @@ module Sastrawi
 
             return if matches[0] == 'r' || /^er(.*)$/.match(matches[1])
 
-            return matches[0] << matches[1]
+            return "#{matches[0]}#{matches[1]}"
           end
         end
       end

--- a/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule9.rb
+++ b/lib/sastrawi/morphology/disambiguator/disambiguator_prefix_rule9.rb
@@ -10,7 +10,7 @@ module Sastrawi
 
             return if matches[0] == 'r'
 
-            return matches[0] << 'er' << matches[1] << matches[2]
+            return "#{matches[0]}er#{matches[1]}#{matches[2]}"
           end
         end
       end

--- a/lib/sastrawi/stemmer/context/context.rb
+++ b/lib/sastrawi/stemmer/context/context.rb
@@ -103,12 +103,12 @@ module Sastrawi
             next unless suffix_removal?(reverse_removal)
 
             if reverse_removal.removed_part == 'kan'
-              @current_word = reverse_removal.result << 'k'
+              @current_word = "#{reverse_removal.result}k"
 
               remove_prefixes
               return if @dictionary.contains?(@current_word)
 
-              @current_word = reverse_removal.result << 'kan'
+              @current_word = "#{reverse_removal.result}kan"
             else
               @current_word = reverse_removal.subject
             end

--- a/lib/sastrawi/stemmer/stemmer.rb
+++ b/lib/sastrawi/stemmer/stemmer.rb
@@ -70,14 +70,14 @@ module Sastrawi
 
         if suffixes.include?(suffix) && second_match
           words[0] = second_match[1]
-          words[1] = second_match[2] << '-' << suffix
+          words[1] = "#{second_match[2]}-#{suffix}"
         end
 
         root_first_word = stem_singular_word(words[0])
         root_second_word = stem_singular_word(words[1])
 
         if !@dictionary.contains?(words[1]) && root_second_word == words[1]
-          root_second_word = stem_singular_word('me' << words[1])
+          root_second_word = stem_singular_word("me#{words[1]}")
         end
 
         if root_first_word == root_second_word


### PR DESCRIPTION
This PR fixes issue #4.

I changed the way to combine strings by using string interpolation. String interpolation doesn't change the value of the object to be concatenated. This changes is not only applied for previously mentioned lines but also other line that uses `<<` operator.

`<<` operator suits better for [concatenating large data chucks](https://rubystyle.guide/#concat-strings). Since current implementation doesn't do that, string interpolation should be prefered (more idiomatic).